### PR TITLE
Remove {} as default for resolver config

### DIFF
--- a/loris/resolvers/api.py
+++ b/loris/resolvers/api.py
@@ -8,7 +8,7 @@ logger = getLogger('loris')
 
 class AbstractResolver(metaclass=ABCMeta):
 
-    def __init__(self, config={}): # pylint:disable=dangerous-default-value
+    def __init__(self, config):
         self.description = config.get('description')
         self.__dict__ = { **self.__dict__, **config }
         logger.debug('Initialized %s.%s', __name__, self.__class__.__name__)

--- a/tests/loris/resolvers/magic_characterizer_mixin_tests.py
+++ b/tests/loris/resolvers/magic_characterizer_mixin_tests.py
@@ -26,5 +26,5 @@ class TestMagicCharacterizerMixin(object):
                 fmt = MyResolver.characterize(color_jpg)
                 return (color_jpg, fmt)
 
-        resolver = MyResolver()
+        resolver = MyResolver({})
         assert resolver.resolve(color_jpg) == (color_jpg, 'jpg')


### PR DESCRIPTION
Closes #146. Less changes than I was initially thinking.